### PR TITLE
bump pangeo-notebook to 2020.11.06

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,7 +2,7 @@ name: myenv
 channels:
   - conda-forge
 dependencies:
-  - pangeo-notebook==2020.07.03
+  - pangeo-notebook==2020.11.06
   - xarray
   - hvplot
   - pip


### PR DESCRIPTION
Necessary for GatewayCluster to start